### PR TITLE
Carousel Arrows Accessibility Updates to Support Label Props

### DIFF
--- a/src/carousel/CarouselArrows.js
+++ b/src/carousel/CarouselArrows.js
@@ -53,6 +53,8 @@ export default function CarouselArrows({
   count,
   setSelected,
   infinite,
+  leftArrowLabel,
+  rightArrowLabel,
 }) {
   classes = useStyles({ classes })
 
@@ -70,6 +72,7 @@ export default function CarouselArrows({
         <IconButton
           className={clsx(classes.arrow, classes.leftArrow)}
           onClick={createOnClickArrow(-1)}
+          aria-label={leftArrowLabel}
         >
           <ChevronLeft classes={{ root: classes.icon }} />
         </IconButton>
@@ -78,6 +81,7 @@ export default function CarouselArrows({
         <IconButton
           className={clsx(classes.arrow, classes.rightArrow)}
           onClick={createOnClickArrow(1)}
+          aria-label={rightArrowLabel}
         >
           <ChevronRight classes={{ root: classes.icon }} />
         </IconButton>
@@ -111,6 +115,19 @@ CarouselArrows.propTypes = {
    * Total number of slides in the [`Carousel`](/apiReference/carousel/Carousel).
    */
   count: PropTypes.number,
+
+  /**
+   * Label given to the left arrow for accessbility purposes.
+   */
+  leftArrowLabel: PropTypes.string,
+
+  /**
+   * Label given to the right arrow for accessbility purposes.
+   */
+  rightArrowLabel: PropTypes.string,
 }
 
-CarouselArrows.defaultProps = {}
+CarouselArrows.defaultProps = {
+  leftArrowLabel: 'Previous',
+  rightArrowLabel: 'Next',
+}


### PR DESCRIPTION
Currently the arrow buttons of the Carousel component are causing accessibility issues because the buttons are considered empty. There is no text or description that would allow a user without sight to understand the context and purpose of the button.

This update adds the ability to pass in 2 new props to the CarouselArrows component, specifically a "leftArrowLabel" and a "rightArrowLabel" prop and sets them as the aria-label attribute of the left and right arrows, respectively. 

If no values are passed for these props, they will simply have the default values of "Previous" and "Next", giving the end user a better understanding of what the buttons do and ensuring that the buttons are never empty.