### PR TITLE
Replace unsupported dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-storefront",
-  "version": "8.17.3",
+  "version": "8.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7287,7 +7287,17 @@
     "delegate": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
+      "optional": true
+    },
+    "delegate-it": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/delegate-it/-/delegate-it-3.0.0.tgz",
+      "integrity": "sha512-ztFzEozkpXQr6OJf7WRgHc71gtT8HUpM6UrqoNDrIeog+FyaOGguIarCuehRBP2jNpriZwyJObx6kKmMZ54Gfw==",
+      "requires": {
+        "typed-query-selector": "^2.4.1"
+      }
     },
     "delegates": {
       "version": "1.0.0",
@@ -20097,6 +20107,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typed-query-selector": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.4.1.tgz",
+      "integrity": "sha512-X6fx0EywD73wsH/w0X2YMqx9wiW99vIhN9nptTP+uvNB5wk0U3t1zzq50IFgdtxbwFP8Ap3N7k7BL2vmKJf4+g=="
     },
     "typed-styles": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chalk": "^3.0.0",
     "clsx": "^1.0.4",
     "csso": "^4.0.3",
-    "delegate": "^3.2.0",
+    "delegate-it": "^3.0.0",
     "formidable": "^1.2.1",
     "glob": "^7.1.6",
     "isomorphic-unfetch": "^3.0.0",

--- a/src/router/useSimpleNavigation.js
+++ b/src/router/useSimpleNavigation.js
@@ -1,4 +1,4 @@
-import delegate from 'delegate'
+import delegate from 'delegate-it'
 import fetch from '../fetch'
 import { useEffect, useRef, useCallback } from 'react'
 import Router from 'next/router'
@@ -24,7 +24,7 @@ export default function useSimpleNavigation() {
 
   useEffect(() => {
     async function doEffect() {
-      delegate('a', 'click', e => {
+      delegate(document, 'a', 'click', e => {
         const { delegateTarget } = e
         const as = delegateTarget.getAttribute('href')
         const href = getRoute(as, routes.current)


### PR DESCRIPTION
`delegate` has several bugs and it hasn't been updated since 2017: https://github.com/zenorocha/delegate

I forked it a few years ago and modernized it along the way: https://github.com/fregante/delegate-it

Being a fork, the API is identical, but browser compatibility now lacks IE due to a `.closest` and `WeakMap` (Edge 15+) 