### PR TITLE
Misc carousel fixes

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react'
+import React, { Fragment, useCallback, useState } from 'react'
 import clsx from 'clsx'
 import { makeStyles } from '@material-ui/core/styles'
 import SwipeableViews from 'react-swipeable-views'
@@ -108,6 +108,16 @@ const Carousel = React.forwardRef((props, ref) => {
     return <Fragment key={key}>{slide}</Fragment>
   }
 
+  const onChangeIndex = useCallback((index) => {
+    if (!infinite) {
+      setSelected(index)
+      return
+    }
+
+    const nextSelected = Math.abs(index - count * Math.floor(index / count))
+    setSelected(nextSelected)
+  }, [infinite, count, selected, setSelected])
+
   return (
     <div
       ref={ref}
@@ -122,7 +132,7 @@ const Carousel = React.forwardRef((props, ref) => {
         <div className={classes.swipeWrap}>
           <Tag
             index={selected}
-            onChangeIndex={setSelected}
+            onChangeIndex={onChangeIndex}
             className={classes.autoPlaySwipeableViews}
             style={swipeStyle}
             slideStyle={slideStyle}

--- a/src/carousel/CarouselArrows.js
+++ b/src/carousel/CarouselArrows.js
@@ -61,9 +61,16 @@ export default function CarouselArrows({
   const createOnClickArrow = useCallback(
     idxChange => evt => {
       evt.preventDefault()
-      setSelected(selected + idxChange)
+
+      let nextSelected = selected + idxChange
+
+      if (infinite) {
+        nextSelected = Math.abs(nextSelected - count * Math.floor(nextSelected / count))
+      }
+
+      setSelected(nextSelected)
     },
-    [selected, setSelected],
+    [selected, setSelected, count, infinite],
   )
 
   return (

--- a/src/carousel/CarouselDots.js
+++ b/src/carousel/CarouselDots.js
@@ -16,13 +16,6 @@ const styles = theme => ({
   },
 
   /**
-   * Styles applied to the dot representing the selected slide.
-   */
-  dotSelected: {
-    backgroundColor: theme.palette.text.primary,
-  },
-
-  /**
    * Styles applied to each dot element.
    */
   dot: {
@@ -38,6 +31,13 @@ const styles = theme => ({
     // Same duration as SwipeableViews animation
     transitionDuration: '0.35s',
   },
+
+  /**
+   * Styles applied to the dot representing the selected slide.
+   */
+  dotSelected: {
+    backgroundColor: theme.palette.text.primary,
+  }
 })
 
 const useStyles = makeStyles(styles, { name: 'RSFCarouselDots' })


### PR DESCRIPTION
This PR fixes a css specificity issue that prevents the currently selected thumbnail dot from being styled properly.

We currently have to use a theme override to fix this bug:

```
RSFCarouselDots: {
  dotSelected: {
    '&&': {
      background: fade(theme.palette.primary.dark, 1)
    }
  }
}
```

___

This PR also fixes the state of the carousel so that the proper index state is set when looping through the set of images, which also fixes the selected state for the carousel dots.