### PR TITLE
Fix carousel selected state and dots

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -114,8 +114,15 @@ const Carousel = React.forwardRef((props, ref) => {
       return
     }
 
-    const nextSelected = Math.abs(index - count * Math.floor(index / count))
-    setSelected(nextSelected)
+    // carousel loop-around calculations
+    let nextSelectedIndex = index;
+    if (nextSelectedIndex + 1 > count) {
+      nextSelectedIndex = 0;
+    } else if (nextSelectedIndex < 0) {
+      nextSelectedIndex = count - 1;
+    }
+
+    setSelected(nextSelectedIndex)
   }, [infinite, count, selected, setSelected])
 
   return (

--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react'
+import React, { Fragment, useCallback, useState } from 'react'
 import clsx from 'clsx'
 import { makeStyles } from '@material-ui/core/styles'
 import SwipeableViews from 'react-swipeable-views'
@@ -108,6 +108,16 @@ const Carousel = React.forwardRef((props, ref) => {
     return <Fragment key={key}>{slide}</Fragment>
   }
 
+  const onChangeIndex = useCallback((index) => {
+    if (!infinite) {
+      setSelected(index)
+      return
+    }
+
+    const nextSelected = Math.abs(index - count * Math.floor(index / count))
+    setSelected(nextSelected)
+  }, [infinite, count, selected, setSelected])
+
   return (
     <div
       ref={ref}
@@ -122,7 +132,7 @@ const Carousel = React.forwardRef((props, ref) => {
         <div className={classes.swipeWrap}>
           <Tag
             index={selected}
-            onChangeIndex={setSelected}
+            onChangeIndex={onChangeIndex}
             className={classes.autoPlaySwipeableViews}
             style={swipeStyle}
             slideStyle={slideStyle}

--- a/src/carousel/CarouselArrows.js
+++ b/src/carousel/CarouselArrows.js
@@ -61,9 +61,16 @@ export default function CarouselArrows({
   const createOnClickArrow = useCallback(
     idxChange => evt => {
       evt.preventDefault()
-      setSelected(selected + idxChange)
+
+      let nextSelected = selected + idxChange
+
+      if (infinite) {
+        nextSelected = Math.abs(nextSelected - count * Math.floor(nextSelected / count))
+      }
+
+      setSelected(nextSelected)
     },
-    [selected, setSelected],
+    [selected, setSelected, count, infinite],
   )
 
   return (

--- a/src/carousel/CarouselArrows.js
+++ b/src/carousel/CarouselArrows.js
@@ -62,13 +62,20 @@ export default function CarouselArrows({
     idxChange => evt => {
       evt.preventDefault()
 
-      let nextSelected = selected + idxChange
-
-      if (infinite) {
-        nextSelected = Math.abs(nextSelected - count * Math.floor(nextSelected / count))
+      if (!infinite) {
+        setSelected(selected + idxChange);
+        return;
       }
 
-      setSelected(nextSelected)
+      // carousel loop-around calculations
+      let nextSelectedIndex = selected + idxChange;
+      if (nextSelectedIndex + 1 > count) {
+        nextSelectedIndex = 0;
+      } else if (nextSelectedIndex < 0) {
+        nextSelectedIndex = count - 1;
+      }
+
+      setSelected(nextSelectedIndex);
     },
     [selected, setSelected, count, infinite],
   )

--- a/src/carousel/CarouselDots.js
+++ b/src/carousel/CarouselDots.js
@@ -16,13 +16,6 @@ const styles = theme => ({
   },
 
   /**
-   * Styles applied to the dot representing the selected slide.
-   */
-  dotSelected: {
-    backgroundColor: theme.palette.text.primary,
-  },
-
-  /**
    * Styles applied to each dot element.
    */
   dot: {
@@ -38,6 +31,13 @@ const styles = theme => ({
     // Same duration as SwipeableViews animation
     transitionDuration: '0.35s',
   },
+
+  /**
+   * Styles applied to the dot representing the selected slide.
+   */
+  dotSelected: {
+    backgroundColor: theme.palette.text.primary,
+  }
 })
 
 const useStyles = makeStyles(styles, { name: 'RSFCarouselDots' })

--- a/src/carousel/CarouselThumbnails.js
+++ b/src/carousel/CarouselThumbnails.js
@@ -6,7 +6,6 @@ import Tab from '@material-ui/core/Tab'
 import { makeStyles, useTheme } from '@material-ui/core/styles'
 import useMediaQuery from '@material-ui/core/useMediaQuery'
 import Image from '../Image'
-import mod from '../utils/mod'
 
 export const styles = theme => ({
   /**
@@ -139,7 +138,7 @@ function CarouselThumbnails({
   return (
     <div className={clsx(className, styles.thumbs)}>
       <Tabs
-        value={selected ? mod(selected, count) : false}
+        value={selected}
         variant="scrollable"
         onChange={(_, index) => setSelected(index)}
         orientation={isVertical ? 'vertical' : 'horizontal'}


### PR DESCRIPTION
- fixes an issue where the `selected` state was not properly calculated when looping through the first and last images in the set
- fixes the selected carousel dots styling (css specificity issue)
- fixes an issue where the first thumbnail could never have the `selectedTab` classname applied