### PR TITLE
Rename ExpansionPanel component to Accordion

### DIFF
--- a/src/ExpandableSection.js
+++ b/src/ExpandableSection.js
@@ -1,12 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import clsx from 'clsx'
-import {
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
-  Typography,
-} from '@material-ui/core'
+import { Accordion, AccordionDetails, AccordionSummary, Typography } from '@material-ui/core'
 import { ExpandMore as ExpandMoreIcon } from '@material-ui/icons'
 import { makeStyles } from '@material-ui/core/styles'
 import useStateFromProp from './hooks/useStateFromProp'
@@ -171,7 +166,7 @@ export default function ExpandableSection(props) {
   const [expandedState, setExpandedState] = useStateFromProp(expanded || defaultExpanded || false)
 
   /**
-   * Gets the classes for the ExpansionPanelSummary
+   * Gets the classes for the AccordionSummary
    * Here we add a class to remove the rotate transform if we're using a
    * separate icon for the collapse state.
    */
@@ -199,7 +194,7 @@ export default function ExpandableSection(props) {
   })
 
   return (
-    <ExpansionPanel
+    <Accordion
       classes={{
         root: clsx({
           [classes.root]: true,
@@ -212,7 +207,7 @@ export default function ExpandableSection(props) {
       {...others}
       onChange={handleChange}
     >
-      <ExpansionPanelSummary
+      <AccordionSummary
         expandIcon={
           expandedState ? (
             <CollapseIcon className={classes.collapseIcon} />
@@ -236,9 +231,9 @@ export default function ExpandableSection(props) {
             {caption}
           </Typography>
         )}
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails classes={{ root: classes.details }}>{children}</ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionSummary>
+      <AccordionDetails classes={{ root: classes.details }}>{children}</AccordionDetails>
+    </Accordion>
   )
 }
 

--- a/test/Accordion.test.js
+++ b/test/Accordion.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import Accordion from 'react-storefront/Accordion'
 import ExpandableSection from 'react-storefront/ExpandableSection'
-import { ExpansionPanelSummary, ExpansionPanel } from '@material-ui/core'
+import { AccordionSummary, Accordion as MUIAccordion } from '@material-ui/core'
 
 describe('Accordion', () => {
   it('should be empty render without children', () => {
@@ -32,25 +32,24 @@ describe('Accordion', () => {
     )
 
     it('should have 3 sections', () => {
-      expect(wrapper.find(ExpansionPanelSummary).length).toBe(3)
+      expect(wrapper.find(AccordionSummary).length).toBe(3)
     })
 
     it('should have 0 expanded sections', () => {
       expect(
-        wrapper.find(ExpansionPanelSummary).filterWhere(panel => panel.prop('expanded') === true)
-          .length,
+        wrapper.find(AccordionSummary).filterWhere(panel => panel.prop('expanded') === true).length,
       ).toBe(0)
     })
 
     it('should expand section on section click ', () => {
       wrapper
-        .find(ExpansionPanelSummary)
+        .find(AccordionSummary)
         .last()
         .simulate('click')
 
       expect(
         wrapper
-          .find(ExpansionPanel)
+          .find(MUIAccordion)
           .last()
           .prop('expanded'),
       ).toBe(true)
@@ -58,66 +57,66 @@ describe('Accordion', () => {
 
     it('should verify that previous opened section is closed on new section click', () => {
       wrapper
-        .find(ExpansionPanelSummary)
+        .find(AccordionSummary)
         .first()
         .simulate('click')
 
       expect(
         wrapper
-          .find(ExpansionPanel)
+          .find(MUIAccordion)
           .first()
           .prop('expanded'),
       ).toBe(true)
 
       wrapper
-        .find(ExpansionPanelSummary)
+        .find(AccordionSummary)
         .last()
         .simulate('click')
 
       expect(
         wrapper
-          .find(ExpansionPanel)
+          .find(MUIAccordion)
           .first()
           .prop('expanded'),
       ).toBe(false)
 
       expect(
         wrapper
-          .find(ExpansionPanel)
+          .find(MUIAccordion)
           .last()
           .prop('expanded'),
       ).toBe(true)
 
       expect(
-        wrapper.find(ExpansionPanel).filterWhere(panel => panel.prop('expanded') === true).length,
+        wrapper.find(MUIAccordion).filterWhere(panel => panel.prop('expanded') === true).length,
       ).toBe(1)
     })
 
     it('should close the section if clicked again on the same section', () => {
       wrapper
-        .find(ExpansionPanelSummary)
+        .find(AccordionSummary)
         .first()
         .simulate('click')
       expect(
         wrapper
-          .find(ExpansionPanel)
+          .find(MUIAccordion)
           .first()
           .prop('expanded'),
       ).toBe(true)
 
       wrapper
-        .find(ExpansionPanelSummary)
+        .find(AccordionSummary)
         .first()
         .simulate('click')
       expect(
         wrapper
-          .find(ExpansionPanel)
+          .find(MUIAccordion)
           .first()
           .prop('expanded'),
       ).toBe(false)
 
       expect(
-        wrapper.find(ExpansionPanel).filterWhere(panel => panel.prop('expanded') === true).length,
+        wrapper.find(MUIAccordion).filterWhere(panel => panel.prop('expanded') === true).length,
       ).toBe(0)
     })
   })

--- a/test/ExpandableSection.test.js
+++ b/test/ExpandableSection.test.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { mount } from 'enzyme'
 import ExpandableSection from 'react-storefront/ExpandableSection'
-import { ExpansionPanel, ExpansionPanelSummary, Typography } from '@material-ui/core'
+import { Accordion, AccordionSummary, Typography } from '@material-ui/core'
 import { ArrowBack as TestIcon, ExpandMore as ExpandMoreIcon } from '@material-ui/icons'
 
 describe('ExpandableSection', () => {
@@ -73,10 +73,10 @@ describe('ExpandableSection', () => {
 
   it('should set specific styles on margin prop', () => {
     wrapper = mount(<ExpandableSection margins={false} />)
-    expect(wrapper.find(ExpansionPanel).prop('classes').root).not.toContain('margins')
+    expect(wrapper.find(Accordion).prop('classes').root).not.toContain('margins')
 
     wrapper = mount(<ExpandableSection margins={true} />)
-    expect(wrapper.find(ExpansionPanel).prop('classes').root).toContain('margins')
+    expect(wrapper.find(Accordion).prop('classes').root).toContain('margins')
   })
 
   it('should set fixed expanded state when expanded prop provided', () => {
@@ -85,14 +85,14 @@ describe('ExpandableSection', () => {
     expect(wrapper.find(TestIcon).exists()).toBe(true)
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(true)
-    wrapper.find(ExpansionPanelSummary).simulate('click')
+    wrapper.find(AccordionSummary).simulate('click')
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(true)
@@ -103,14 +103,14 @@ describe('ExpandableSection', () => {
 
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(false)
-    wrapper.find(ExpansionPanelSummary).simulate('click')
+    wrapper.find(AccordionSummary).simulate('click')
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(true)
@@ -136,18 +136,18 @@ describe('ExpandableSection', () => {
     expect(wrapper.find(TestIcon).exists()).toBe(true)
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(true)
 
-    wrapper.find(ExpansionPanelSummary).simulate('click')
+    wrapper.find(AccordionSummary).simulate('click')
 
     expect(wrapper.find(ExpandMoreIcon).exists()).toBe(true)
     expect(wrapper.find(TestIcon).exists()).toBe(false)
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(false)
@@ -166,19 +166,19 @@ describe('ExpandableSection', () => {
 
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(false)
 
     wrapper
-      .find(ExpansionPanel)
+      .find(Accordion)
       .childAt(0)
       .simulate('click')
 
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(false)
@@ -195,16 +195,16 @@ describe('ExpandableSection', () => {
 
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(false)
 
-    wrapper.find(ExpansionPanelSummary).simulate('click')
+    wrapper.find(AccordionSummary).simulate('click')
 
     expect(
       wrapper
-        .find(ExpansionPanel)
+        .find(Accordion)
         .childAt(0)
         .prop('expanded'),
     ).toBe(true)


### PR DESCRIPTION
The ExpansionPanel component was renamed to Accordion to use a more common naming convention.

You should use `import { Accordion } from '@material-ui/core'` or `import Accordion from '@material-ui/core/Accordion'`.