### PR TITLE
ISSUE #202 Update quantity if product already exist in cart

### DIFF
--- a/src/mock-connector/utils/cartStore.js
+++ b/src/mock-connector/utils/cartStore.js
@@ -3,8 +3,8 @@ import createProduct from './createProduct'
 const CART_COOKIE = 'rsf_mock_cart'
 
 const initialStore = [
-  { id: 1, quantity: 1 },
-  { id: 2, quantity: 1 },
+  { id: '1', quantity: 1 },
+  { id: '2', quantity: 1 },
 ]
 
 function getStore(req, res) {
@@ -43,7 +43,12 @@ export function removeItem(id, req, res) {
 }
 
 export function addItem(id, quantity, req, res) {
-  const newStore = [{ id, quantity }, ...getStore(req, res)]
+  const currentStore = getStore(req, res);
+  const isItemExist = currentStore.find((item) => item.id === id);
+  if (isItemExist !== undefined) {
+    return updateItem(id, isItemExist.quantity + 1, req, res);
+  }
+  const newStore = [{ id, quantity }, ...currentStore]
   res.setHeader('Set-Cookie', `${CART_COOKIE}=${JSON.stringify(newStore)}; Path=/`)
   return newStore.map(toProduct)
 }


### PR DESCRIPTION
Checking if product exist in store then call `updateCart` function with `existing quantity + 1` on click of "Add to Cart"

**Before**

![image](https://user-images.githubusercontent.com/3704506/149737032-42a856bb-8eca-47c6-83e0-c9172a7ba409.png)

**After**

![image](https://user-images.githubusercontent.com/3704506/149739583-59c41273-673f-4f13-af8b-8c612e3586d4.png)

> Note :- Only the initial store has `id` of product as `Number`. And then if we do "Add to cart" from anywhere it is being added as `string`. Hence made it `string` in initial store as well.

